### PR TITLE
Refactor RAG agent to use corpusName instead of teacherId

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ swagger:
 
 # Generate protobuf Go code
 proto:
-	protoc --go_out=$(PROTO_OUT) --go-grpc_out=$(PROTO_OUT) $(PROTO_SRC)
+	protoc --go_out=. --go-grpc_out=. internal/proto/ai_service.proto
 
 # Run with Swagger and Proto regeneration
 dev-all:

--- a/internal/controller/ai/rag_controller.go
+++ b/internal/controller/ai/rag_controller.go
@@ -39,14 +39,14 @@ func RAGAgentHandler(c *gin.Context) {
 	}
 
 	// Create/verify corpus for the teacher before processing the request
-	_, err := createVertexAICorpus(req.TeacherId)
+	_, err := createVertexAICorpus(req.CorpusName)
 	if err != nil {
-		log.Printf("WARNING: Could not create/verify corpus for teacher %s: %v", req.TeacherId, err)
+		log.Printf("WARNING: Could not create/verify corpus for teacher %s: %v", req.CorpusName, err)
 		// Continue processing even if corpus creation fails
 	}
 
 	// Call the gRPC microservice
-	resp, err := service.RAGAgentClient(req.TeacherId, req.Message)
+	resp, err := service.RAGAgentClient(req.CorpusName, req.Message)
 	if err != nil {
 		log.Printf("ERROR: Failed to process RAG agent request: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to process RAG agent request", "error": err.Error()})
@@ -54,7 +54,7 @@ func RAGAgentHandler(c *gin.Context) {
 	}
 
 	// Process the agent response to determine data content and message
-	responseData, responseMessage, err := processRAGAgentResponse(resp.GetAgentResponse(), req.TeacherId)
+	responseData, responseMessage, err := processRAGAgentResponse(resp.GetAgentResponse(), req.CorpusName)
 	if err != nil {
 		log.Printf("ERROR: Failed to process RAG agent response: %v", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"message": "Failed to process RAG agent response", "error": err.Error()})
@@ -64,7 +64,7 @@ func RAGAgentHandler(c *gin.Context) {
 	// Build standardized response format (matching /ai/agent structure)
 	standardizedResponse := map[string]interface{}{
 		"message":      responseMessage,
-		"teacherId":    resp.GetTeacherId(),
+		"corpusName":   resp.GetCorpusName(),
 		"agentName":    resp.GetAgentName(),
 		"data":         responseData,
 		"sessionId":    resp.GetSessionId(),
@@ -432,10 +432,10 @@ func listVertexAICorpusContent(corpusName string) (map[string]interface{}, error
 // processRAGAgentResponse processes the agent response from Python microservice
 // If it's structured JSON with questions, saves them to MongoDB and returns question IDs
 // If it's regular text, returns it as-is
-func processRAGAgentResponse(agentResponse, teacherId string) (interface{}, string, error) {
+func processRAGAgentResponse(agentResponse, CorpusName string) (interface{}, string, error) {
 	log.Printf("=== PROCESS RAG AGENT RESPONSE START ===")
-	log.Printf("[AI] Processing RAG agent response for teacherId: %s", teacherId)
-	log.Printf("[AI] Agent response length: %d characters", len(agentResponse))
+	log.Printf("[AI] Processing RAG agent response for corpusName: %s", CorpusName)
+	log.Printf("[AI] Agent response: %s", agentResponse)
 
 	// Try to parse as JSON to see if it contains structured questions
 	log.Printf("[AI] Attempting to parse agent response as JSON...")
@@ -472,7 +472,7 @@ func processRAGAgentResponse(agentResponse, teacherId string) (interface{}, stri
 
 	// Create result structure
 	result := map[string]interface{}{
-		"corpusUsed":              teacherId,
+		"corpusUsed":              CorpusName,
 		"mcqs":                    make([]interface{}, 0),
 		"msqs":                    make([]interface{}, 0),
 		"nats":                    make([]interface{}, 0),

--- a/internal/controller/ai/types.go
+++ b/internal/controller/ai/types.go
@@ -64,12 +64,12 @@ type AgentRequest struct {
 }
 
 type RAGAgentRequest struct {
-	TeacherId string `json:"teacherId" binding:"required"`
-	Role      string `json:"role" binding:"required"`
-	Message   string `json:"message" binding:"required"`
-	File      string `json:"file"`
-	CreatedAt string `json:"createdAt"`
-	UpdatedAt string `json:"updatedAt"`
+	CorpusName string `json:"corpusName" binding:"required"`
+	Role       string `json:"role" binding:"required"`
+	Message    string `json:"message" binding:"required"`
+	File       string `json:"file"`
+	CreatedAt  string `json:"createdAt"`
+	UpdatedAt  string `json:"updatedAt"`
 }
 
 // --- Response Types ---

--- a/internal/grpc_service/agent_client.go
+++ b/internal/grpc_service/agent_client.go
@@ -172,7 +172,7 @@ func Agent(file, fileType, teacherId, role, message, createdAt, updatedAt string
 
 		if assignmentResultData != nil {
 			// Handle assignment result saving (from assessor agent)
-			if assignmentResult, err := handleAssignmentResultSaving(assignmentResultData, teacherId); err == nil {
+			if assignmentResult, err := handleAssignmentResultSaving(assignmentResultData); err == nil {
 				responseData = assignmentResult
 				agentName = "assessor_agent"
 				responseMessage = "Assignment assessment completed successfully"
@@ -183,7 +183,7 @@ func Agent(file, fileType, teacherId, role, message, createdAt, updatedAt string
 			}
 		} else if len(agentResponse.QuestionsRequested) > 0 {
 			// Handle question generation (both AGG and AGT)
-			if questionsData, err := handleQuestionGeneration(agentResponse.QuestionsRequested, teacherId, rawAgentResponse); err == nil {
+			if questionsData, err := handleQuestionGeneration(agentResponse.QuestionsRequested, rawAgentResponse); err == nil {
 				responseData = questionsData
 				agentName = "assignment_generator_general"
 				responseMessage = "Assignment generated successfully"
@@ -291,7 +291,7 @@ func createErrorResponse(teacherId, errorMessage string, res *pb.AgentResponse) 
 	}
 }
 
-func handleQuestionGeneration(questionsRequested []QuestionRequest, teacherId string, rawAgentResponse string) (map[string]interface{}, error) {
+func handleQuestionGeneration(questionsRequested []QuestionRequest, rawAgentResponse string) (map[string]interface{}, error) {
 	// Parse the raw agent response to extract title and body
 	var agentResponseData map[string]interface{}
 	var assignmentTitle, assignmentBody string
@@ -929,7 +929,7 @@ func handleReportCardGeneration(reportCardDataInterface interface{}, teacherId s
 }
 
 // handleAssignmentResultSaving processes assignment result data from assessor agent
-func handleAssignmentResultSaving(assignmentResultData interface{}, teacherId string) (map[string]interface{}, error) {
+func handleAssignmentResultSaving(assignmentResultData interface{}) (map[string]interface{}, error) {
 	// Convert interface{} to map[string]interface{}
 	resultMap, ok := assignmentResultData.(map[string]interface{})
 	if !ok {
@@ -1111,7 +1111,7 @@ func createRAGErrorResponse(teacherId, errorMessage string, res *pb.RAGAgentResp
 }
 */
 
-func RAGAgentClient(teacherId string, message string) (*pb.RAGAgentResponse, error) {
+func RAGAgentClient(corpusName string, message string) (*pb.RAGAgentResponse, error) {
 	client, conn, err := DialGRPC()
 	if err != nil {
 		log.Printf("ERROR: Failed to establish gRPC connection: %v", err)
@@ -1123,8 +1123,8 @@ func RAGAgentClient(teacherId string, message string) (*pb.RAGAgentResponse, err
 	defer cancel()
 
 	req := &pb.RAGAgentRequest{
-		TeacherId: teacherId,
-		Message:   message,
+		CorpusName: corpusName,
+		Message:    message,
 	}
 
 	resp, err := client.RAGAgent(ctx, req)

--- a/internal/proto/ai_service.proto
+++ b/internal/proto/ai_service.proto
@@ -120,7 +120,7 @@ message AgentResponse {
 }
 
 message RAGAgentRequest {
-    string teacherId = 1;
+    string corpusName = 1;
     string message = 2;
     string role = 3;
     string createdAt = 4;
@@ -129,7 +129,7 @@ message RAGAgentRequest {
 
 message RAGAgentResponse {
     string message = 1;
-    string teacherId = 2;
+    string corpusName = 2;
     string agent_name = 3;
     string agent_response = 4;
     string session_id = 5;

--- a/internal/proto/ai_service/ai_service.pb.go
+++ b/internal/proto/ai_service/ai_service.pb.go
@@ -1123,7 +1123,7 @@ func (x *AgentResponse) GetFeedback() string {
 
 type RAGAgentRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	TeacherId     string                 `protobuf:"bytes,1,opt,name=teacherId,proto3" json:"teacherId,omitempty"`
+	CorpusName    string                 `protobuf:"bytes,1,opt,name=corpusName,proto3" json:"corpusName,omitempty"`
 	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
 	Role          string                 `protobuf:"bytes,3,opt,name=role,proto3" json:"role,omitempty"`
 	CreatedAt     string                 `protobuf:"bytes,4,opt,name=createdAt,proto3" json:"createdAt,omitempty"`
@@ -1162,9 +1162,9 @@ func (*RAGAgentRequest) Descriptor() ([]byte, []int) {
 	return file_internal_proto_ai_service_proto_rawDescGZIP(), []int{19}
 }
 
-func (x *RAGAgentRequest) GetTeacherId() string {
+func (x *RAGAgentRequest) GetCorpusName() string {
 	if x != nil {
-		return x.TeacherId
+		return x.CorpusName
 	}
 	return ""
 }
@@ -1200,7 +1200,7 @@ func (x *RAGAgentRequest) GetUpdatedAt() string {
 type RAGAgentResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Message       string                 `protobuf:"bytes,1,opt,name=message,proto3" json:"message,omitempty"`
-	TeacherId     string                 `protobuf:"bytes,2,opt,name=teacherId,proto3" json:"teacherId,omitempty"`
+	CorpusName    string                 `protobuf:"bytes,2,opt,name=corpusName,proto3" json:"corpusName,omitempty"`
 	AgentName     string                 `protobuf:"bytes,3,opt,name=agent_name,json=agentName,proto3" json:"agent_name,omitempty"`
 	AgentResponse string                 `protobuf:"bytes,4,opt,name=agent_response,json=agentResponse,proto3" json:"agent_response,omitempty"`
 	SessionId     string                 `protobuf:"bytes,5,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
@@ -1250,9 +1250,9 @@ func (x *RAGAgentResponse) GetMessage() string {
 	return ""
 }
 
-func (x *RAGAgentResponse) GetTeacherId() string {
+func (x *RAGAgentResponse) GetCorpusName() string {
 	if x != nil {
-		return x.TeacherId
+		return x.CorpusName
 	}
 	return ""
 }
@@ -1399,16 +1399,20 @@ const file_internal_proto_ai_service_proto_rawDesc = "" +
 	"\rresponse_time\x18\b \x01(\tR\fresponseTime\x12\x12\n" +
 	"\x04role\x18\t \x01(\tR\x04role\x12\x1a\n" +
 	"\bfeedback\x18\n" +
-	" \x01(\tR\bfeedback\"\x99\x01\n" +
-	"\x0fRAGAgentRequest\x12\x1c\n" +
-	"\tteacherId\x18\x01 \x01(\tR\tteacherId\x12\x18\n" +
+	" \x01(\tR\bfeedback\"\x9b\x01\n" +
+	"\x0fRAGAgentRequest\x12\x1e\n" +
+	"\n" +
+	"corpusName\x18\x01 \x01(\tR\n" +
+	"corpusName\x12\x18\n" +
 	"\amessage\x18\x02 \x01(\tR\amessage\x12\x12\n" +
 	"\x04role\x18\x03 \x01(\tR\x04role\x12\x1c\n" +
 	"\tcreatedAt\x18\x04 \x01(\tR\tcreatedAt\x12\x1c\n" +
-	"\tupdatedAt\x18\x05 \x01(\tR\tupdatedAt\"\xc0\x02\n" +
+	"\tupdatedAt\x18\x05 \x01(\tR\tupdatedAt\"\xc2\x02\n" +
 	"\x10RAGAgentResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessage\x12\x1c\n" +
-	"\tteacherId\x18\x02 \x01(\tR\tteacherId\x12\x1d\n" +
+	"\amessage\x18\x01 \x01(\tR\amessage\x12\x1e\n" +
+	"\n" +
+	"corpusName\x18\x02 \x01(\tR\n" +
+	"corpusName\x12\x1d\n" +
 	"\n" +
 	"agent_name\x18\x03 \x01(\tR\tagentName\x12%\n" +
 	"\x0eagent_response\x18\x04 \x01(\tR\ragentResponse\x12\x1d\n" +


### PR DESCRIPTION
Replaces all references to teacherId with corpusName in RAG agent request/response types, controller logic, gRPC client, and protobuf definitions. Updates related function signatures and logging for clarity and consistency with the new naming convention.